### PR TITLE
chore: changed CF's bittorrent tracker host

### DIFF
--- a/meerkat.ts
+++ b/meerkat.ts
@@ -44,7 +44,7 @@ export default class Meerkat extends EventEmitter {
 
     this.announce = announce || [
       'wss://tracker.openwebtorrent.com',
-      'wss://dev.tracker.cf-identity-wallet.metadata.dev.cf-deployments.org',
+      'wss://dev.btt.cf-identity-wallet.metadata.dev.cf-deployments.org',
       'wss://tracker.files.fm:7073/announce',
       'ws://tracker.files.fm:7072/announce',
       'wss://tracker.openwebtorrent.com:443/announce',


### PR DESCRIPTION
Today Robe updated the CF's bittorrent tracker host and IP. In this PR I have updated the list of trackers to include this change. 